### PR TITLE
Enable C++11 For-Each usage

### DIFF
--- a/include/cajun/json/elements.h
+++ b/include/cajun/json/elements.h
@@ -5,27 +5,27 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
-	  notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
-	  notice, this list of conditions and the following disclaimer in the
-	  documentation and/or other materials provided with the distribution.
- * Neither the name of the projecct nor the names of its contributors
-	  may be used to endorse or promote products derived from this software
-	  without specific prior written permission.
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the projecct nor the names of its contributors 
+      may be used to endorse or promote products derived from this software 
+      without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
 ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
- ******************************************************************************/
+******************************************************************************/
 
 #pragma once
 
@@ -34,273 +34,263 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <stdexcept>
 
-/*
+/*  
 
 TODO:
- * better documentation (doxygen?)
- * Unicode support
- * parent element accessors
+* better documentation (doxygen?)
+* Unicode support
+* parent element accessors
 
- */
+*/
+
+namespace json
+{
 
-namespace json {
+namespace Version
+{
+   enum { MAJOR = 2 };
+   enum { MINOR = 0 };
+   enum {ENGINEERING = 2 };
+}
 
-	namespace Version {
+/////////////////////////////////////////////////
+// forward declarations (more info further below)
 
-		enum {
-			MAJOR = 2
-		};
 
-		enum {
-			MINOR = 0
-		};
+class Visitor;
+class ConstVisitor;
 
-		enum {
-			ENGINEERING = 2
-		};
-	}
+template <typename ValueTypeT>
+class TrivialType_T;
 
-	/////////////////////////////////////////////////
-	// forward declarations (more info further below)
+typedef TrivialType_T<double> Number;
+typedef TrivialType_T<bool> Boolean;
+typedef TrivialType_T<std::string> String;
 
+class Object;
+class Array;
+class Null;
 
-	class Visitor;
-	class ConstVisitor;
 
-	template <typename ValueTypeT>
-	class TrivialType_T;
 
-	typedef TrivialType_T<double> Number;
-	typedef TrivialType_T<bool> Boolean;
-	typedef TrivialType_T<std::string> String;
+/////////////////////////////////////////////////////////////////////////
+// Exception - base class for all JSON-related runtime errors
 
-	class Object;
-	class Array;
-	class Null;
+class Exception : public std::runtime_error
+{
+public:
+   Exception(const std::string& sMessage);
+};
 
 
 
-	/////////////////////////////////////////////////////////////////////////
-	// Exception - base class for all JSON-related runtime errors
 
-	class Exception : public std::runtime_error {
-	public:
-		Exception(const std::string& sMessage);
-	};
+/////////////////////////////////////////////////////////////////////////
+// UnknownElement - provides a typesafe surrogate for any of the JSON-
+//  sanctioned element types. This class allows the Array and Object
+//  class to effectively contain a heterogeneous set of child elements.
+// The cast operators provide convenient implicit downcasting, while
+//  preserving dynamic type safety by throwing an exception during a
+//  a bad cast. 
+// The object & array element index operators (operators [std::string]
+//  and [size_t]) provide convenient, quick access to child elements.
+//  They are a logical extension of the cast operators. These child
+//  element accesses can be chained together, allowing the following
+//  (when document structure is well-known):
+//  String str = objInvoices[1]["Customer"]["Company"];
+
+
+class UnknownElement
+{
+public:
+   UnknownElement();
+   UnknownElement(const UnknownElement& unknown);
+   UnknownElement(const Object& object);
+   UnknownElement(const Array& array);
+   UnknownElement(const Number& number);
+   UnknownElement(const Boolean& boolean);
+   UnknownElement(const String& string);
+   UnknownElement(const Null& null);
 
+   ~UnknownElement();
 
+   UnknownElement& operator = (const UnknownElement& unknown);
 
+   // implicit cast to actual element type. throws on failure
+   operator const Object& () const;
+   operator const Array& () const;
+   operator const Number& () const;
+   operator const Boolean& () const;
+   operator const String& () const;
+   operator const Null& () const;
 
-	/////////////////////////////////////////////////////////////////////////
-	// UnknownElement - provides a typesafe surrogate for any of the JSON-
-	//  sanctioned element types. This class allows the Array and Object
-	//  class to effectively contain a heterogeneous set of child elements.
-	// The cast operators provide convenient implicit downcasting, while
-	//  preserving dynamic type safety by throwing an exception during a
-	//  a bad cast.
-	// The object & array element index operators (operators [std::string]
-	//  and [size_t]) provide convenient, quick access to child elements.
-	//  They are a logical extension of the cast operators. These child
-	//  element accesses can be chained together, allowing the following
-	//  (when document structure is well-known):
-	//  String str = objInvoices[1]["Customer"]["Company"];
+   // implicit cast to actual element type. *converts* on failure, and always returns success
+   operator Object& ();
+   operator Array& ();
+   operator Number& ();
+   operator Boolean& ();
+   operator String& ();
+   operator Null& ();
 
-	class UnknownElement {
-	public:
-		UnknownElement();
-		UnknownElement(const UnknownElement& unknown);
-		UnknownElement(const Object& object);
-		UnknownElement(const Array& array);
-		UnknownElement(const Number& number);
-		UnknownElement(const Boolean& boolean);
-		UnknownElement(const String& string);
-		UnknownElement(const Null& null);
+   // provides quick access to children when real element type is object
+   UnknownElement& operator[] (const std::string& key);
+   const UnknownElement& operator[] (const std::string& key) const;
 
-		~UnknownElement();
+   // provides quick access to children when real element type is array
+   UnknownElement& operator[] (size_t index);
+   const UnknownElement& operator[] (size_t index) const;
 
-		UnknownElement& operator=(const UnknownElement& unknown);
+   // implements visitor pattern
+   void Accept(ConstVisitor& visitor) const;
+   void Accept(Visitor& visitor);
 
-		// implicit cast to actual element type. throws on failure
-		operator const Object& () const;
-		operator const Array& () const;
-		operator const Number& () const;
-		operator const Boolean& () const;
-		operator const String& () const;
-		operator const Null& () const;
+   // tests equality. first checks type, then value if possible
+   bool operator == (const UnknownElement& element) const;
 
-		// implicit cast to actual element type. *converts* on failure, and always returns success
-		operator Object& ();
-		operator Array& ();
-		operator Number& ();
-		operator Boolean& ();
-		operator String& ();
-		operator Null& ();
+private:
+   class Imp;
 
-		// provides quick access to children when real element type is object
-		UnknownElement& operator[](const std::string& key);
-		const UnknownElement& operator[](const std::string& key) const;
+   template <typename ElementTypeT>
+   class Imp_T;
 
-		// provides quick access to children when real element type is array
-		UnknownElement& operator[](size_t index);
-		const UnknownElement& operator[](size_t index) const;
+   class CastVisitor;
+   class ConstCastVisitor;
+   
+   template <typename ElementTypeT>
+   class CastVisitor_T;
 
-		// implements visitor pattern
-		void Accept(ConstVisitor& visitor) const;
-		void Accept(Visitor& visitor);
+   template <typename ElementTypeT>
+   class ConstCastVisitor_T;
 
-		// tests equality. first checks type, then value if possible
-		bool operator==(const UnknownElement& element) const;
+   template <typename ElementTypeT>
+   const ElementTypeT& CastTo() const;
 
-	private:
-		class Imp;
+   template <typename ElementTypeT>
+   ElementTypeT& ConvertTo();
 
-		template <typename ElementTypeT>
-		class Imp_T;
+   Imp* m_pImp;
+};
 
-		class CastVisitor;
-		class ConstCastVisitor;
 
-		template <typename ElementTypeT>
-		class CastVisitor_T;
+/////////////////////////////////////////////////////////////////////////////////
+// Array - mimics std::deque<UnknownElement>. The array contents are effectively 
+//  heterogeneous thanks to the ElementUnknown class. push_back has been replaced 
+//  by more generic insert functions.
 
-		template <typename ElementTypeT>
-		class ConstCastVisitor_T;
+class Array
+{
+public:
+   typedef std::deque<UnknownElement> Elements;
+   typedef Elements::iterator iterator;
+   typedef Elements::const_iterator const_iterator;
 
-		template <typename ElementTypeT>
-		const ElementTypeT& CastTo() const;
+   iterator Begin();
+   iterator End();
+   const_iterator Begin() const;
+   const_iterator End() const;
+   
+   iterator Insert(const UnknownElement& element, iterator itWhere);
+   iterator Insert(const UnknownElement& element);
+   iterator Erase(iterator itWhere);
+   void Resize(size_t newSize);
+   void Clear();
 
-		template <typename ElementTypeT>
-		ElementTypeT& ConvertTo();
+   size_t Size() const;
+   bool Empty() const;
 
-		Imp* m_pImp;
-	};
+   UnknownElement& operator[] (size_t index);
+   const UnknownElement& operator[] (size_t index) const;
 
+   bool operator == (const Array& array) const;
 
-	/////////////////////////////////////////////////////////////////////////////////
-	// Array - mimics std::deque<UnknownElement>. The array contents are effectively
-	//  heterogeneous thanks to the ElementUnknown class. push_back has been replaced
-	//  by more generic insert functions.
+private:
+   Elements m_Elements;
+};
 
-	class Array {
-	public:
-		typedef std::deque<UnknownElement> Elements;
-		typedef Elements::iterator iterator;
-		typedef Elements::const_iterator const_iterator;
 
-		iterator Begin();
-		iterator End();
-		const_iterator Begin() const;
-		const_iterator End() const;
+/////////////////////////////////////////////////////////////////////////////////
+// Object - mimics std::map<std::string, UnknownElement>. The member value 
+//  contents are effectively heterogeneous thanks to the UnknownElement class
 
-		iterator begin();
-		iterator end();
-		const_iterator begin() const;
-		const_iterator end() const;
+class Object
+{
+public:
+   struct Member {
+      Member(const std::string& nameIn = std::string(), const UnknownElement& elementIn = UnknownElement());
 
-		iterator Insert(const UnknownElement& element, iterator itWhere);
-		iterator Insert(const UnknownElement& element);
-		iterator Erase(iterator itWhere);
-		void Resize(size_t newSize);
-		void Clear();
+      bool operator == (const Member& member) const;
 
-		size_t Size() const;
-		bool Empty() const;
+      std::string name;
+      UnknownElement element;
+   };
 
-		UnknownElement& operator[](size_t index);
-		const UnknownElement& operator[](size_t index) const;
+   typedef std::list<Member> Members; // map faster, but does not preserve order
+   typedef Members::iterator iterator;
+   typedef Members::const_iterator const_iterator;
 
-		bool operator==(const Array& array) const;
+   bool operator == (const Object& object) const;
 
-	private:
-		Elements m_Elements;
-	};
+   iterator Begin();
+   iterator End();
+   const_iterator Begin() const;
+   const_iterator End() const;
 
+   size_t Size() const;
+   bool Empty() const;
 
-	/////////////////////////////////////////////////////////////////////////////////
-	// Object - mimics std::map<std::string, UnknownElement>. The member value
-	//  contents are effectively heterogeneous thanks to the UnknownElement class
+   iterator Find(const std::string& name);
+   const_iterator Find(const std::string& name) const;
 
-	class Object {
-	public:
+   iterator Insert(const Member& member);
+   iterator Insert(const Member& member, iterator itWhere);
+   iterator Erase(iterator itWhere);
+   void Clear();
 
-		struct Member {
-			Member(const std::string& nameIn = std::string(), const UnknownElement& elementIn = UnknownElement());
+   UnknownElement& operator [](const std::string& name);
+   const UnknownElement& operator [](const std::string& name) const;
 
-			bool operator==(const Member& member) const;
+private:
+   class Finder;
 
-			std::string name;
-			UnknownElement element;
-		};
+   Members m_Members;
+};
 
-		typedef std::list<Member> Members; // map faster, but does not preserve order
-		typedef Members::iterator iterator;
-		typedef Members::const_iterator const_iterator;
 
-		bool operator==(const Object& object) const;
+/////////////////////////////////////////////////////////////////////////////////
+// TrivialType_T - class template for encapsulates a simple data type, such as
+//  a string, number, or boolean. Provides implicit const & noncost cast operators
+//  for that type, allowing "DataTypeT type = trivialType;"
 
-		iterator Begin();
-		iterator End();
-		const_iterator Begin() const;
-		const_iterator End() const;
 
-		iterator begin();
-		iterator end();
-		const_iterator begin() const;
-		const_iterator end() const;
+template <typename DataTypeT>
+class TrivialType_T
+{
+public:
+   TrivialType_T(const DataTypeT& t = DataTypeT());
 
-		size_t Size() const;
-		bool Empty() const;
+   operator DataTypeT&();
+   operator const DataTypeT&() const;
 
-		iterator Find(const std::string& name);
-		const_iterator Find(const std::string& name) const;
+   DataTypeT& Value();
+   const DataTypeT& Value() const;
 
-		iterator Insert(const Member& member);
-		iterator Insert(const Member& member, iterator itWhere);
-		iterator Erase(iterator itWhere);
-		void Clear();
+   bool operator == (const TrivialType_T<DataTypeT>& trivial) const;
 
-		UnknownElement& operator[](const std::string& name);
-		const UnknownElement& operator[](const std::string& name) const;
+private:
+   DataTypeT m_tValue;
+};
 
-	private:
-		class Finder;
 
-		Members m_Members;
-	};
 
+/////////////////////////////////////////////////////////////////////////////////
+// Null - doesn't do much of anything but satisfy the JSON spec. It is the default
+//  element type of UnknownElement
 
-	/////////////////////////////////////////////////////////////////////////////////
-	// TrivialType_T - class template for encapsulates a simple data type, such as
-	//  a string, number, or boolean. Provides implicit const & noncost cast operators
-	//  for that type, allowing "DataTypeT type = trivialType;"
-
-	template <typename DataTypeT>
-	class TrivialType_T {
-	public:
-		TrivialType_T(const DataTypeT& t = DataTypeT());
-
-		operator DataTypeT&();
-		operator const DataTypeT&() const;
-
-		DataTypeT& Value();
-		const DataTypeT& Value() const;
-
-		bool operator==(const TrivialType_T<DataTypeT>& trivial) const;
-
-	private:
-		DataTypeT m_tValue;
-	};
-
-
-
-	/////////////////////////////////////////////////////////////////////////////////
-	// Null - doesn't do much of anything but satisfy the JSON spec. It is the default
-	//  element type of UnknownElement
-
-	class Null {
-	public:
-		bool operator==(const Null& trivial) const;
-	};
+class Null
+{
+public:
+   bool operator == (const Null& trivial) const;
+};
 
 
 } // End namespace

--- a/include/cajun/json/elements.h
+++ b/include/cajun/json/elements.h
@@ -188,6 +188,11 @@ public:
    iterator End();
    const_iterator Begin() const;
    const_iterator End() const;
+
+   iterator begin();
+   iterator end();
+   const_iterator begin() const;
+   const_iterator end() const;
    
    iterator Insert(const UnknownElement& element, iterator itWhere);
    iterator Insert(const UnknownElement& element);
@@ -234,6 +239,11 @@ public:
    iterator End();
    const_iterator Begin() const;
    const_iterator End() const;
+
+   iterator begin();
+   iterator end();
+   const_iterator begin() const;
+   const_iterator end() const;
 
    size_t Size() const;
    bool Empty() const;

--- a/include/cajun/json/elements.h
+++ b/include/cajun/json/elements.h
@@ -5,27 +5,27 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright 
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the projecct nor the names of its contributors 
-      may be used to endorse or promote products derived from this software 
-      without specific prior written permission.
+ * Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+ * Neither the name of the projecct nor the names of its contributors
+	  may be used to endorse or promote products derived from this software
+	  without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
 ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-******************************************************************************/
+ ******************************************************************************/
 
 #pragma once
 
@@ -34,263 +34,273 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <stdexcept>
 
-/*  
+/*
 
 TODO:
-* better documentation (doxygen?)
-* Unicode support
-* parent element accessors
+ * better documentation (doxygen?)
+ * Unicode support
+ * parent element accessors
 
-*/
-
-namespace json
-{
+ */
 
-namespace Version
-{
-   enum { MAJOR = 2 };
-   enum { MINOR = 0 };
-   enum {ENGINEERING = 2 };
-}
+namespace json {
 
-/////////////////////////////////////////////////
-// forward declarations (more info further below)
+	namespace Version {
 
+		enum {
+			MAJOR = 2
+		};
 
-class Visitor;
-class ConstVisitor;
+		enum {
+			MINOR = 0
+		};
 
-template <typename ValueTypeT>
-class TrivialType_T;
+		enum {
+			ENGINEERING = 2
+		};
+	}
 
-typedef TrivialType_T<double> Number;
-typedef TrivialType_T<bool> Boolean;
-typedef TrivialType_T<std::string> String;
+	/////////////////////////////////////////////////
+	// forward declarations (more info further below)
 
-class Object;
-class Array;
-class Null;
 
+	class Visitor;
+	class ConstVisitor;
 
+	template <typename ValueTypeT>
+	class TrivialType_T;
 
-/////////////////////////////////////////////////////////////////////////
-// Exception - base class for all JSON-related runtime errors
+	typedef TrivialType_T<double> Number;
+	typedef TrivialType_T<bool> Boolean;
+	typedef TrivialType_T<std::string> String;
 
-class Exception : public std::runtime_error
-{
-public:
-   Exception(const std::string& sMessage);
-};
+	class Object;
+	class Array;
+	class Null;
 
 
 
+	/////////////////////////////////////////////////////////////////////////
+	// Exception - base class for all JSON-related runtime errors
 
-/////////////////////////////////////////////////////////////////////////
-// UnknownElement - provides a typesafe surrogate for any of the JSON-
-//  sanctioned element types. This class allows the Array and Object
-//  class to effectively contain a heterogeneous set of child elements.
-// The cast operators provide convenient implicit downcasting, while
-//  preserving dynamic type safety by throwing an exception during a
-//  a bad cast. 
-// The object & array element index operators (operators [std::string]
-//  and [size_t]) provide convenient, quick access to child elements.
-//  They are a logical extension of the cast operators. These child
-//  element accesses can be chained together, allowing the following
-//  (when document structure is well-known):
-//  String str = objInvoices[1]["Customer"]["Company"];
-
-
-class UnknownElement
-{
-public:
-   UnknownElement();
-   UnknownElement(const UnknownElement& unknown);
-   UnknownElement(const Object& object);
-   UnknownElement(const Array& array);
-   UnknownElement(const Number& number);
-   UnknownElement(const Boolean& boolean);
-   UnknownElement(const String& string);
-   UnknownElement(const Null& null);
+	class Exception : public std::runtime_error {
+	public:
+		Exception(const std::string& sMessage);
+	};
 
-   ~UnknownElement();
 
-   UnknownElement& operator = (const UnknownElement& unknown);
 
-   // implicit cast to actual element type. throws on failure
-   operator const Object& () const;
-   operator const Array& () const;
-   operator const Number& () const;
-   operator const Boolean& () const;
-   operator const String& () const;
-   operator const Null& () const;
 
-   // implicit cast to actual element type. *converts* on failure, and always returns success
-   operator Object& ();
-   operator Array& ();
-   operator Number& ();
-   operator Boolean& ();
-   operator String& ();
-   operator Null& ();
+	/////////////////////////////////////////////////////////////////////////
+	// UnknownElement - provides a typesafe surrogate for any of the JSON-
+	//  sanctioned element types. This class allows the Array and Object
+	//  class to effectively contain a heterogeneous set of child elements.
+	// The cast operators provide convenient implicit downcasting, while
+	//  preserving dynamic type safety by throwing an exception during a
+	//  a bad cast.
+	// The object & array element index operators (operators [std::string]
+	//  and [size_t]) provide convenient, quick access to child elements.
+	//  They are a logical extension of the cast operators. These child
+	//  element accesses can be chained together, allowing the following
+	//  (when document structure is well-known):
+	//  String str = objInvoices[1]["Customer"]["Company"];
 
-   // provides quick access to children when real element type is object
-   UnknownElement& operator[] (const std::string& key);
-   const UnknownElement& operator[] (const std::string& key) const;
+	class UnknownElement {
+	public:
+		UnknownElement();
+		UnknownElement(const UnknownElement& unknown);
+		UnknownElement(const Object& object);
+		UnknownElement(const Array& array);
+		UnknownElement(const Number& number);
+		UnknownElement(const Boolean& boolean);
+		UnknownElement(const String& string);
+		UnknownElement(const Null& null);
 
-   // provides quick access to children when real element type is array
-   UnknownElement& operator[] (size_t index);
-   const UnknownElement& operator[] (size_t index) const;
+		~UnknownElement();
 
-   // implements visitor pattern
-   void Accept(ConstVisitor& visitor) const;
-   void Accept(Visitor& visitor);
+		UnknownElement& operator=(const UnknownElement& unknown);
 
-   // tests equality. first checks type, then value if possible
-   bool operator == (const UnknownElement& element) const;
+		// implicit cast to actual element type. throws on failure
+		operator const Object& () const;
+		operator const Array& () const;
+		operator const Number& () const;
+		operator const Boolean& () const;
+		operator const String& () const;
+		operator const Null& () const;
 
-private:
-   class Imp;
+		// implicit cast to actual element type. *converts* on failure, and always returns success
+		operator Object& ();
+		operator Array& ();
+		operator Number& ();
+		operator Boolean& ();
+		operator String& ();
+		operator Null& ();
 
-   template <typename ElementTypeT>
-   class Imp_T;
+		// provides quick access to children when real element type is object
+		UnknownElement& operator[](const std::string& key);
+		const UnknownElement& operator[](const std::string& key) const;
 
-   class CastVisitor;
-   class ConstCastVisitor;
-   
-   template <typename ElementTypeT>
-   class CastVisitor_T;
+		// provides quick access to children when real element type is array
+		UnknownElement& operator[](size_t index);
+		const UnknownElement& operator[](size_t index) const;
 
-   template <typename ElementTypeT>
-   class ConstCastVisitor_T;
+		// implements visitor pattern
+		void Accept(ConstVisitor& visitor) const;
+		void Accept(Visitor& visitor);
 
-   template <typename ElementTypeT>
-   const ElementTypeT& CastTo() const;
+		// tests equality. first checks type, then value if possible
+		bool operator==(const UnknownElement& element) const;
 
-   template <typename ElementTypeT>
-   ElementTypeT& ConvertTo();
+	private:
+		class Imp;
 
-   Imp* m_pImp;
-};
+		template <typename ElementTypeT>
+		class Imp_T;
 
+		class CastVisitor;
+		class ConstCastVisitor;
 
-/////////////////////////////////////////////////////////////////////////////////
-// Array - mimics std::deque<UnknownElement>. The array contents are effectively 
-//  heterogeneous thanks to the ElementUnknown class. push_back has been replaced 
-//  by more generic insert functions.
+		template <typename ElementTypeT>
+		class CastVisitor_T;
 
-class Array
-{
-public:
-   typedef std::deque<UnknownElement> Elements;
-   typedef Elements::iterator iterator;
-   typedef Elements::const_iterator const_iterator;
+		template <typename ElementTypeT>
+		class ConstCastVisitor_T;
 
-   iterator Begin();
-   iterator End();
-   const_iterator Begin() const;
-   const_iterator End() const;
-   
-   iterator Insert(const UnknownElement& element, iterator itWhere);
-   iterator Insert(const UnknownElement& element);
-   iterator Erase(iterator itWhere);
-   void Resize(size_t newSize);
-   void Clear();
+		template <typename ElementTypeT>
+		const ElementTypeT& CastTo() const;
 
-   size_t Size() const;
-   bool Empty() const;
+		template <typename ElementTypeT>
+		ElementTypeT& ConvertTo();
 
-   UnknownElement& operator[] (size_t index);
-   const UnknownElement& operator[] (size_t index) const;
+		Imp* m_pImp;
+	};
 
-   bool operator == (const Array& array) const;
 
-private:
-   Elements m_Elements;
-};
+	/////////////////////////////////////////////////////////////////////////////////
+	// Array - mimics std::deque<UnknownElement>. The array contents are effectively
+	//  heterogeneous thanks to the ElementUnknown class. push_back has been replaced
+	//  by more generic insert functions.
 
+	class Array {
+	public:
+		typedef std::deque<UnknownElement> Elements;
+		typedef Elements::iterator iterator;
+		typedef Elements::const_iterator const_iterator;
 
-/////////////////////////////////////////////////////////////////////////////////
-// Object - mimics std::map<std::string, UnknownElement>. The member value 
-//  contents are effectively heterogeneous thanks to the UnknownElement class
+		iterator Begin();
+		iterator End();
+		const_iterator Begin() const;
+		const_iterator End() const;
 
-class Object
-{
-public:
-   struct Member {
-      Member(const std::string& nameIn = std::string(), const UnknownElement& elementIn = UnknownElement());
+		iterator begin();
+		iterator end();
+		const_iterator begin() const;
+		const_iterator end() const;
 
-      bool operator == (const Member& member) const;
+		iterator Insert(const UnknownElement& element, iterator itWhere);
+		iterator Insert(const UnknownElement& element);
+		iterator Erase(iterator itWhere);
+		void Resize(size_t newSize);
+		void Clear();
 
-      std::string name;
-      UnknownElement element;
-   };
+		size_t Size() const;
+		bool Empty() const;
 
-   typedef std::list<Member> Members; // map faster, but does not preserve order
-   typedef Members::iterator iterator;
-   typedef Members::const_iterator const_iterator;
+		UnknownElement& operator[](size_t index);
+		const UnknownElement& operator[](size_t index) const;
 
-   bool operator == (const Object& object) const;
+		bool operator==(const Array& array) const;
 
-   iterator Begin();
-   iterator End();
-   const_iterator Begin() const;
-   const_iterator End() const;
+	private:
+		Elements m_Elements;
+	};
 
-   size_t Size() const;
-   bool Empty() const;
 
-   iterator Find(const std::string& name);
-   const_iterator Find(const std::string& name) const;
+	/////////////////////////////////////////////////////////////////////////////////
+	// Object - mimics std::map<std::string, UnknownElement>. The member value
+	//  contents are effectively heterogeneous thanks to the UnknownElement class
 
-   iterator Insert(const Member& member);
-   iterator Insert(const Member& member, iterator itWhere);
-   iterator Erase(iterator itWhere);
-   void Clear();
+	class Object {
+	public:
 
-   UnknownElement& operator [](const std::string& name);
-   const UnknownElement& operator [](const std::string& name) const;
+		struct Member {
+			Member(const std::string& nameIn = std::string(), const UnknownElement& elementIn = UnknownElement());
 
-private:
-   class Finder;
+			bool operator==(const Member& member) const;
 
-   Members m_Members;
-};
+			std::string name;
+			UnknownElement element;
+		};
 
+		typedef std::list<Member> Members; // map faster, but does not preserve order
+		typedef Members::iterator iterator;
+		typedef Members::const_iterator const_iterator;
 
-/////////////////////////////////////////////////////////////////////////////////
-// TrivialType_T - class template for encapsulates a simple data type, such as
-//  a string, number, or boolean. Provides implicit const & noncost cast operators
-//  for that type, allowing "DataTypeT type = trivialType;"
+		bool operator==(const Object& object) const;
 
+		iterator Begin();
+		iterator End();
+		const_iterator Begin() const;
+		const_iterator End() const;
 
-template <typename DataTypeT>
-class TrivialType_T
-{
-public:
-   TrivialType_T(const DataTypeT& t = DataTypeT());
+		iterator begin();
+		iterator end();
+		const_iterator begin() const;
+		const_iterator end() const;
 
-   operator DataTypeT&();
-   operator const DataTypeT&() const;
+		size_t Size() const;
+		bool Empty() const;
 
-   DataTypeT& Value();
-   const DataTypeT& Value() const;
+		iterator Find(const std::string& name);
+		const_iterator Find(const std::string& name) const;
 
-   bool operator == (const TrivialType_T<DataTypeT>& trivial) const;
+		iterator Insert(const Member& member);
+		iterator Insert(const Member& member, iterator itWhere);
+		iterator Erase(iterator itWhere);
+		void Clear();
 
-private:
-   DataTypeT m_tValue;
-};
+		UnknownElement& operator[](const std::string& name);
+		const UnknownElement& operator[](const std::string& name) const;
 
+	private:
+		class Finder;
 
+		Members m_Members;
+	};
 
-/////////////////////////////////////////////////////////////////////////////////
-// Null - doesn't do much of anything but satisfy the JSON spec. It is the default
-//  element type of UnknownElement
 
-class Null
-{
-public:
-   bool operator == (const Null& trivial) const;
-};
+	/////////////////////////////////////////////////////////////////////////////////
+	// TrivialType_T - class template for encapsulates a simple data type, such as
+	//  a string, number, or boolean. Provides implicit const & noncost cast operators
+	//  for that type, allowing "DataTypeT type = trivialType;"
+
+	template <typename DataTypeT>
+	class TrivialType_T {
+	public:
+		TrivialType_T(const DataTypeT& t = DataTypeT());
+
+		operator DataTypeT&();
+		operator const DataTypeT&() const;
+
+		DataTypeT& Value();
+		const DataTypeT& Value() const;
+
+		bool operator==(const TrivialType_T<DataTypeT>& trivial) const;
+
+	private:
+		DataTypeT m_tValue;
+	};
+
+
+
+	/////////////////////////////////////////////////////////////////////////////////
+	// Null - doesn't do much of anything but satisfy the JSON spec. It is the default
+	//  element type of UnknownElement
+
+	class Null {
+	public:
+		bool operator==(const Null& trivial) const;
+	};
 
 
 } // End namespace

--- a/include/cajun/json/elements.inl
+++ b/include/cajun/json/elements.inl
@@ -5,23 +5,23 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright 
+    * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the projecct nor the names of its contributors 
-      may be used to endorse or promote products derived from this software 
+    * Neither the name of the projecct nor the names of its contributors
+      may be used to endorse or promote products derived from this software
       without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
 ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <map>
 
-/*  
+/*
 
 TODO:
 * better documentation
@@ -154,13 +154,13 @@ inline UnknownElement::operator Boolean& ()   { return ConvertTo<Boolean>(); }
 inline UnknownElement::operator String& ()    { return ConvertTo<String>(); }
 inline UnknownElement::operator Null& ()      { return ConvertTo<Null>(); }
 
-inline UnknownElement& UnknownElement::operator = (const UnknownElement& unknown) 
+inline UnknownElement& UnknownElement::operator = (const UnknownElement& unknown)
 {
    // always check for this
    if (&unknown != this)
    {
       // we might be copying from a subtree of ourselves. delete the old imp
-      //  only after the clone operation is complete. yes, this could be made 
+      //  only after the clone operation is complete. yes, this could be made
       //  more efficient, but isn't worth the complexity
       Imp* pOldImp = m_pImp;
       m_pImp = unknown.m_pImp->Clone();
@@ -212,7 +212,7 @@ const ElementTypeT& UnknownElement::CastTo() const
 
 
 template <typename ElementTypeT>
-ElementTypeT& UnknownElement::ConvertTo() 
+ElementTypeT& UnknownElement::ConvertTo()
 {
    CastVisitor_T<ElementTypeT> castVisitor;
    m_pImp->Accept(castVisitor);
@@ -245,7 +245,7 @@ inline bool UnknownElement::operator == (const UnknownElement& element) const
 inline Object::Member::Member(const std::string& nameIn, const UnknownElement& elementIn) :
    name(nameIn), element(elementIn) {}
 
-inline bool Object::Member::operator == (const Member& member) const 
+inline bool Object::Member::operator == (const Member& member) const
 {
    return name == member.name &&
           element == member.element;
@@ -270,15 +270,20 @@ inline Object::iterator Object::End() { return m_Members.end(); }
 inline Object::const_iterator Object::Begin() const { return m_Members.begin(); }
 inline Object::const_iterator Object::End() const { return m_Members.end(); }
 
+inline Object::iterator Object::begin() { return Begin(); }
+inline Object::iterator Object::end() { return End(); }
+inline Object::const_iterator Object::begin() const { return Begin(); }
+inline Object::const_iterator Object::end() const { return End(); }
+
 inline size_t Object::Size() const { return m_Members.size(); }
 inline bool Object::Empty() const { return m_Members.empty(); }
 
-inline Object::iterator Object::Find(const std::string& name) 
+inline Object::iterator Object::Find(const std::string& name)
 {
    return std::find_if(m_Members.begin(), m_Members.end(), Finder(name));
 }
 
-inline Object::const_iterator Object::Find(const std::string& name) const 
+inline Object::const_iterator Object::Find(const std::string& name) const
 {
    return std::find_if(m_Members.begin(), m_Members.end(), Finder(name));
 }
@@ -298,7 +303,7 @@ inline Object::iterator Object::Insert(const Member& member, iterator itWhere)
    return it;
 }
 
-inline Object::iterator Object::Erase(iterator itWhere) 
+inline Object::iterator Object::Erase(iterator itWhere)
 {
    return m_Members.erase(itWhere);
 }
@@ -312,10 +317,10 @@ inline UnknownElement& Object::operator [](const std::string& name)
       Member member(name);
       it = Insert(member, End());
    }
-   return it->element;      
+   return it->element;
 }
 
-inline const UnknownElement& Object::operator [](const std::string& name) const 
+inline const UnknownElement& Object::operator [](const std::string& name) const
 {
    const_iterator it = Find(name);
    if (it == End())
@@ -323,12 +328,12 @@ inline const UnknownElement& Object::operator [](const std::string& name) const
    return it->element;
 }
 
-inline void Object::Clear() 
+inline void Object::Clear()
 {
-   m_Members.clear(); 
+   m_Members.clear();
 }
 
-inline bool Object::operator == (const Object& object) const 
+inline bool Object::operator == (const Object& object) const
 {
    return m_Members == object.m_Members;
 }
@@ -342,8 +347,13 @@ inline Array::iterator Array::End()    { return m_Elements.end(); }
 inline Array::const_iterator Array::Begin() const  { return m_Elements.begin(); }
 inline Array::const_iterator Array::End() const    { return m_Elements.end(); }
 
+inline Array::iterator Array::begin() { return Begin(); }
+inline Array::iterator Array::end() { return End(); }
+inline Array::const_iterator Array::begin() const { return Begin(); }
+inline Array::const_iterator Array::end() const { return End(); }
+
 inline Array::iterator Array::Insert(const UnknownElement& element, iterator itWhere)
-{ 
+{
    return m_Elements.insert(itWhere, element);
 }
 
@@ -353,7 +363,7 @@ inline Array::iterator Array::Insert(const UnknownElement& element)
 }
 
 inline Array::iterator Array::Erase(iterator itWhere)
-{ 
+{
    return m_Elements.erase(itWhere);
 }
 
@@ -370,14 +380,14 @@ inline UnknownElement& Array::operator[] (size_t index)
    size_t nMinSize = index + 1; // zero indexed
    if (m_Elements.size() < nMinSize)
       m_Elements.resize(nMinSize);
-   return m_Elements[index]; 
+   return m_Elements[index];
 }
 
-inline const UnknownElement& Array::operator[] (size_t index) const 
+inline const UnknownElement& Array::operator[] (size_t index) const
 {
    if (index >= m_Elements.size())
       throw Exception("Array out of bounds");
-   return m_Elements[index]; 
+   return m_Elements[index];
 }
 
 inline void Array::Clear() {
@@ -400,25 +410,25 @@ TrivialType_T<DataTypeT>::TrivialType_T(const DataTypeT& t) :
 template <typename DataTypeT>
 TrivialType_T<DataTypeT>::operator DataTypeT&()
 {
-   return Value(); 
+   return Value();
 }
 
 template <typename DataTypeT>
 TrivialType_T<DataTypeT>::operator const DataTypeT&() const
 {
-   return Value(); 
+   return Value();
 }
 
 template <typename DataTypeT>
 DataTypeT& TrivialType_T<DataTypeT>::Value()
 {
-   return m_tValue; 
+   return m_tValue;
 }
 
 template <typename DataTypeT>
 const DataTypeT& TrivialType_T<DataTypeT>::Value() const
 {
-   return m_tValue; 
+   return m_tValue;
 }
 
 template <typename DataTypeT>

--- a/include/cajun/json/elements.inl
+++ b/include/cajun/json/elements.inl
@@ -270,6 +270,11 @@ inline Object::iterator Object::End() { return m_Members.end(); }
 inline Object::const_iterator Object::Begin() const { return m_Members.begin(); }
 inline Object::const_iterator Object::End() const { return m_Members.end(); }
 
+inline Object::iterator Object::begin() { return Begin(); }
+inline Object::iterator Object::end() { return End(); }
+inline Object::const_iterator Object::begin() const { return Begin(); }
+inline Object::const_iterator Object::end() const { return End(); }
+
 inline size_t Object::Size() const { return m_Members.size(); }
 inline bool Object::Empty() const { return m_Members.empty(); }
 
@@ -341,6 +346,11 @@ inline Array::iterator Array::Begin()  { return m_Elements.begin(); }
 inline Array::iterator Array::End()    { return m_Elements.end(); }
 inline Array::const_iterator Array::Begin() const  { return m_Elements.begin(); }
 inline Array::const_iterator Array::End() const    { return m_Elements.end(); }
+
+inline Array::iterator Array::begin() { return Begin(); }
+inline Array::iterator Array::end() { return End(); }
+inline Array::const_iterator Array::begin() const { return Begin(); }
+inline Array::const_iterator Array::end() const { return End(); }
 
 inline Array::iterator Array::Insert(const UnknownElement& element, iterator itWhere)
 { 

--- a/include/cajun/json/elements.inl
+++ b/include/cajun/json/elements.inl
@@ -5,23 +5,23 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
+    * Redistributions of source code must retain the above copyright 
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the projecct nor the names of its contributors
-      may be used to endorse or promote products derived from this software
+    * Neither the name of the projecct nor the names of its contributors 
+      may be used to endorse or promote products derived from this software 
       without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
 ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <map>
 
-/*
+/*  
 
 TODO:
 * better documentation
@@ -154,13 +154,13 @@ inline UnknownElement::operator Boolean& ()   { return ConvertTo<Boolean>(); }
 inline UnknownElement::operator String& ()    { return ConvertTo<String>(); }
 inline UnknownElement::operator Null& ()      { return ConvertTo<Null>(); }
 
-inline UnknownElement& UnknownElement::operator = (const UnknownElement& unknown)
+inline UnknownElement& UnknownElement::operator = (const UnknownElement& unknown) 
 {
    // always check for this
    if (&unknown != this)
    {
       // we might be copying from a subtree of ourselves. delete the old imp
-      //  only after the clone operation is complete. yes, this could be made
+      //  only after the clone operation is complete. yes, this could be made 
       //  more efficient, but isn't worth the complexity
       Imp* pOldImp = m_pImp;
       m_pImp = unknown.m_pImp->Clone();
@@ -212,7 +212,7 @@ const ElementTypeT& UnknownElement::CastTo() const
 
 
 template <typename ElementTypeT>
-ElementTypeT& UnknownElement::ConvertTo()
+ElementTypeT& UnknownElement::ConvertTo() 
 {
    CastVisitor_T<ElementTypeT> castVisitor;
    m_pImp->Accept(castVisitor);
@@ -245,7 +245,7 @@ inline bool UnknownElement::operator == (const UnknownElement& element) const
 inline Object::Member::Member(const std::string& nameIn, const UnknownElement& elementIn) :
    name(nameIn), element(elementIn) {}
 
-inline bool Object::Member::operator == (const Member& member) const
+inline bool Object::Member::operator == (const Member& member) const 
 {
    return name == member.name &&
           element == member.element;
@@ -270,20 +270,15 @@ inline Object::iterator Object::End() { return m_Members.end(); }
 inline Object::const_iterator Object::Begin() const { return m_Members.begin(); }
 inline Object::const_iterator Object::End() const { return m_Members.end(); }
 
-inline Object::iterator Object::begin() { return Begin(); }
-inline Object::iterator Object::end() { return End(); }
-inline Object::const_iterator Object::begin() const { return Begin(); }
-inline Object::const_iterator Object::end() const { return End(); }
-
 inline size_t Object::Size() const { return m_Members.size(); }
 inline bool Object::Empty() const { return m_Members.empty(); }
 
-inline Object::iterator Object::Find(const std::string& name)
+inline Object::iterator Object::Find(const std::string& name) 
 {
    return std::find_if(m_Members.begin(), m_Members.end(), Finder(name));
 }
 
-inline Object::const_iterator Object::Find(const std::string& name) const
+inline Object::const_iterator Object::Find(const std::string& name) const 
 {
    return std::find_if(m_Members.begin(), m_Members.end(), Finder(name));
 }
@@ -303,7 +298,7 @@ inline Object::iterator Object::Insert(const Member& member, iterator itWhere)
    return it;
 }
 
-inline Object::iterator Object::Erase(iterator itWhere)
+inline Object::iterator Object::Erase(iterator itWhere) 
 {
    return m_Members.erase(itWhere);
 }
@@ -317,10 +312,10 @@ inline UnknownElement& Object::operator [](const std::string& name)
       Member member(name);
       it = Insert(member, End());
    }
-   return it->element;
+   return it->element;      
 }
 
-inline const UnknownElement& Object::operator [](const std::string& name) const
+inline const UnknownElement& Object::operator [](const std::string& name) const 
 {
    const_iterator it = Find(name);
    if (it == End())
@@ -328,12 +323,12 @@ inline const UnknownElement& Object::operator [](const std::string& name) const
    return it->element;
 }
 
-inline void Object::Clear()
+inline void Object::Clear() 
 {
-   m_Members.clear();
+   m_Members.clear(); 
 }
 
-inline bool Object::operator == (const Object& object) const
+inline bool Object::operator == (const Object& object) const 
 {
    return m_Members == object.m_Members;
 }
@@ -347,13 +342,8 @@ inline Array::iterator Array::End()    { return m_Elements.end(); }
 inline Array::const_iterator Array::Begin() const  { return m_Elements.begin(); }
 inline Array::const_iterator Array::End() const    { return m_Elements.end(); }
 
-inline Array::iterator Array::begin() { return Begin(); }
-inline Array::iterator Array::end() { return End(); }
-inline Array::const_iterator Array::begin() const { return Begin(); }
-inline Array::const_iterator Array::end() const { return End(); }
-
 inline Array::iterator Array::Insert(const UnknownElement& element, iterator itWhere)
-{
+{ 
    return m_Elements.insert(itWhere, element);
 }
 
@@ -363,7 +353,7 @@ inline Array::iterator Array::Insert(const UnknownElement& element)
 }
 
 inline Array::iterator Array::Erase(iterator itWhere)
-{
+{ 
    return m_Elements.erase(itWhere);
 }
 
@@ -380,14 +370,14 @@ inline UnknownElement& Array::operator[] (size_t index)
    size_t nMinSize = index + 1; // zero indexed
    if (m_Elements.size() < nMinSize)
       m_Elements.resize(nMinSize);
-   return m_Elements[index];
+   return m_Elements[index]; 
 }
 
-inline const UnknownElement& Array::operator[] (size_t index) const
+inline const UnknownElement& Array::operator[] (size_t index) const 
 {
    if (index >= m_Elements.size())
       throw Exception("Array out of bounds");
-   return m_Elements[index];
+   return m_Elements[index]; 
 }
 
 inline void Array::Clear() {
@@ -410,25 +400,25 @@ TrivialType_T<DataTypeT>::TrivialType_T(const DataTypeT& t) :
 template <typename DataTypeT>
 TrivialType_T<DataTypeT>::operator DataTypeT&()
 {
-   return Value();
+   return Value(); 
 }
 
 template <typename DataTypeT>
 TrivialType_T<DataTypeT>::operator const DataTypeT&() const
 {
-   return Value();
+   return Value(); 
 }
 
 template <typename DataTypeT>
 DataTypeT& TrivialType_T<DataTypeT>::Value()
 {
-   return m_tValue;
+   return m_tValue; 
 }
 
 template <typename DataTypeT>
 const DataTypeT& TrivialType_T<DataTypeT>::Value() const
 {
-   return m_tValue;
+   return m_tValue; 
 }
 
 template <typename DataTypeT>


### PR DESCRIPTION
Added lower-case function names to make compatible with for( x : y ) iterator clauses
